### PR TITLE
Remove lombok

### DIFF
--- a/JTreeMap/pom.xml
+++ b/JTreeMap/pom.xml
@@ -145,12 +145,5 @@
             <version>3.19.0</version>
             <scope>test</scope>
         </dependency>
-        <!-- https://mvnrepository.com/artifact/org.projectlombok/lombok -->
-        <dependency>
-            <groupId>org.projectlombok</groupId>
-            <artifactId>lombok</artifactId>
-            <version>1.18.30</version>
-            <scope>compile</scope>
-        </dependency>
     </dependencies>
 </project>

--- a/JTreeMap/src/main/java/net/sf/jtreemap/swing/DefaultValue.java
+++ b/JTreeMap/src/main/java/net/sf/jtreemap/swing/DefaultValue.java
@@ -32,23 +32,20 @@
  */
 package net.sf.jtreemap.swing;
 
-import lombok.AllArgsConstructor;
-import lombok.EqualsAndHashCode;
-import lombok.NoArgsConstructor;
-
 /**
  * Default Value <BR>
  * The getLabel() method returns the "" + getValue()
  *
  * @author Laurent DUTHEIL
  */
-@EqualsAndHashCode(callSuper = true)
-@AllArgsConstructor
-@NoArgsConstructor
 public class DefaultValue extends Value {
     private static final long serialVersionUID = 367321198951855282L;
 
     private double value;
+    
+    public DefaultValue(double value) {
+        this.value = value;
+    }
 
     /*
      * (non-Javadoc)

--- a/JTreeMap/src/main/java/net/sf/jtreemap/swing/DefaultValue.java
+++ b/JTreeMap/src/main/java/net/sf/jtreemap/swing/DefaultValue.java
@@ -42,7 +42,10 @@ public class DefaultValue extends Value {
     private static final long serialVersionUID = 367321198951855282L;
 
     private double value;
-    
+
+    public DefaultValue() {
+    }
+
     public DefaultValue(double value) {
         this.value = value;
     }

--- a/JTreeMap/src/main/java/net/sf/jtreemap/swing/FormattedValue.java
+++ b/JTreeMap/src/main/java/net/sf/jtreemap/swing/FormattedValue.java
@@ -35,14 +35,11 @@ package net.sf.jtreemap.swing;
 import java.math.BigDecimal;
 import java.text.NumberFormat;
 
-import lombok.EqualsAndHashCode;
-
 /**
  * class who can display the values of elements of a JTreeMap with a formatter.
  *
  * @author Benoit Xhenseval
  */
-@EqualsAndHashCode(callSuper = true)
 public class FormattedValue extends DefaultValue {
     private static final long serialVersionUID = 108728719010392928L;
     private final NumberFormat nf;

--- a/JTreeMap/src/main/java/net/sf/jtreemap/swing/Value.java
+++ b/JTreeMap/src/main/java/net/sf/jtreemap/swing/Value.java
@@ -34,14 +34,11 @@ package net.sf.jtreemap.swing;
 
 import java.io.Serializable;
 
-import lombok.EqualsAndHashCode;
-
 /**
  * Class who permits to associate a double value to a label
  *
  * @author Laurent DUTHEIL
  */
-@EqualsAndHashCode
 public abstract class Value implements Comparable, Serializable {
     private static final long serialVersionUID = 1L;
 
@@ -85,6 +82,29 @@ public abstract class Value implements Comparable, Serializable {
             return this.getValue() > value2.getValue() ? 1 : 0;
         }
         throw new IllegalArgumentException();
+    }
+    
+    @Override
+    public int hashCode() {
+        final String label = getLabel();
+        return Double.hashCode(getValue()) + 31 * (label != null ? 0 : label.hashCode());
+    }
+
+    @Override
+    public boolean equals(final Object value) {
+        if (value != null && Value.class.equals(value.getClass())) {
+            final Value value2 = (Value) value;
+            if (this.getValue() != value2.getValue()) {
+                return false;
+            }
+            
+            if (this.getLabel() == null) {
+                return  value2.getLabel() == null;
+            }
+            
+            return this.getLabel().equals(value2.getLabel());
+        }
+        return false;
     }
 
     @Override

--- a/JTreeMap/src/main/java/net/sf/jtreemap/swing/ValuePercent.java
+++ b/JTreeMap/src/main/java/net/sf/jtreemap/swing/ValuePercent.java
@@ -34,15 +34,11 @@ package net.sf.jtreemap.swing;
 
 import java.text.NumberFormat;
 
-import lombok.EqualsAndHashCode;
-
 /**
  * class who can display the values of elements of a JTreeMap with pourcent
  *
  * @author Laurent Dutheil
  */
-
-@EqualsAndHashCode(callSuper = true)
 public class ValuePercent extends Value {
     private static final long serialVersionUID = 1087258219010392928L;
     private double value;

--- a/JTreeMap/src/main/java/net/sf/jtreemap/swing/provider/HSBTreeMapColorProvider.java
+++ b/JTreeMap/src/main/java/net/sf/jtreemap/swing/provider/HSBTreeMapColorProvider.java
@@ -38,11 +38,13 @@ import java.util.Enumeration;
 
 import javax.swing.JPanel;
 
-import lombok.extern.slf4j.Slf4j;
 import net.sf.jtreemap.swing.DefaultValue;
 import net.sf.jtreemap.swing.JTreeMap;
 import net.sf.jtreemap.swing.TreeMapNode;
 import net.sf.jtreemap.swing.Value;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * An HSB color space color provider for JTreeMap. Uses a specified function to
@@ -52,7 +54,6 @@ import net.sf.jtreemap.swing.Value;
  *
  * @author Andy Adamczak
  */
-@Slf4j
 public class HSBTreeMapColorProvider extends ColorProvider {
     private static final int HSBVAL_SIZE = 3;
 
@@ -60,6 +61,8 @@ public class HSBTreeMapColorProvider extends ColorProvider {
      *
      */
     private static final long serialVersionUID = 5009655580804320847L;
+    
+    private static final Logger log = LoggerFactory.getLogger(RedGreenColorProvider.class);
 
     /**
      * @author Andy Adamczak

--- a/JTreeMap/src/main/java/net/sf/jtreemap/swing/provider/RedGreenColorProvider.java
+++ b/JTreeMap/src/main/java/net/sf/jtreemap/swing/provider/RedGreenColorProvider.java
@@ -37,10 +37,12 @@ import java.awt.Graphics;
 
 import javax.swing.JPanel;
 
-import lombok.extern.slf4j.Slf4j;
 import net.sf.jtreemap.swing.JTreeMap;
 import net.sf.jtreemap.swing.TreeMapNode;
 import net.sf.jtreemap.swing.Value;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * ColorProvider who, with a max absolute value M, choose the color between
@@ -48,10 +50,11 @@ import net.sf.jtreemap.swing.Value;
  *
  * @author Laurent Dutheil
  */
-@Slf4j
 public class RedGreenColorProvider extends ColorProvider {
     private static final long serialVersionUID = 5030306338780462810L;
     private static final int COLOUR_MAX_VALUE = 255;
+    private static final Logger log = LoggerFactory.getLogger(RedGreenColorProvider.class);
+    
     private final JTreeMap jTreeMap;
     private JPanel legend;
     private Value maxAbsValue;


### PR DESCRIPTION
When jtreemap 1.1.3 is used as a dependency and when building on JDK 17 lombok causes an error:

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.12.1:compile (default-compile) on project pilot-jar: Fatal error compiling: java.lang.ExceptionInInitializerError: Unable to make field private com.sun.tools.javac.processing.JavacProcessingEnvironment$DiscoveredProcessors com.sun.tools.javac.processing.JavacProcessingEnvironment.discoveredProcs accessible: module jdk.compiler does not "opens com.sun.tools.javac.processing" to unnamed module @258a8227
```

Although this error should be fixed by upgrading to a recent version of lombok, the project makes very little use of it, so removing it seems like a better solution to me.
Note that I have left lombok in the example project, that one would typically not be used as a library, so using it there isn't an issue.

For this equals/hashcode implementation I'm assuming that the identity of `Value` objects (and descendant classes) is the value/label pair, ignoring the format for instance.

This should fix #15 